### PR TITLE
add: binned correlation to train logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.zip
 game_data
 experiments/trajectories
-__pycache__/
+**/__pycache__/
 *.pyc
 checkpoints*
 model/*
@@ -15,3 +15,4 @@ env.sh
 trajectories/*
 **sbatch**
 notebooks
+results

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,7 @@
 import json
 from collections import namedtuple
 import random
+import numpy as np 
 
 State = namedtuple('State', ('obs', 'description', 'inventory', 'state'))
 Transition = namedtuple('Transition', ('state', 'act', 'reward', 'next_state', 'next_acts', 'done', 'cost'))
@@ -10,6 +11,19 @@ def read_json(file_path):
     with open(file_path, "r") as file:
         data = json.load(file)
     return data
+
+def corr(x, y, rectified=False): 
+    x = np.asarray(x)
+    y = np.asarray(y)
+    x_mean = np.mean(x)
+    y_mean = np.mean(y)
+    x_std = np.std(x)
+    y_std = np.std(y)
+    if x_std == 0 or y_std == 0:
+        return np.nan  # avoid divide-by-zero
+    if rectified:
+        return np.sum(np.maximum(0, x - x_mean) * np.maximum(0, y - y_mean)) / (len(x) * x_std * y_std)
+    return np.sum((x - x_mean) * (y - y_mean)) / (len(x) * x_std * y_std)
 
 class ReplayMemory(object):
     def __init__(self, capacity):


### PR DESCRIPTION
Adds a correlation and rectified correlation between reward and safety cost, calculated for every 100 training runs. 

Also updated gitignore to include `**__pycache__/` as it misses catching the `__pycache__` folder under `src/env/machiavelli`.

Not sure why automatic merge is failing. 